### PR TITLE
Bugfix for image upload widget in admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+django_stdimage.egg-info

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='django-stdimage',
-    version='0.2',
+    version='0.2.1',
     description='Django Standarized Image Field',
     author='garcia.marc',
     author_email='garcia.marc@gmail.com',

--- a/stdimage/widgets.py
+++ b/stdimage/widgets.py
@@ -11,9 +11,11 @@ class DelAdminFileWidget(AdminFileWidget):
 
     def render(self, name, value, attrs=None):
         input = super(forms.widgets.FileInput, self).render(name, value, attrs)
-        if value:
+        if value and hasattr(value, 'field'):
             return mark_safe(render_to_string('stdimage/admin_widget.html', {
-                'name': name, 'value': value, 'input': input,
+                'name': name,
+                'value': value,
+                'input': input,
                 'show_delete_button': value.field.blank,
                 'MEDIA_URL': settings.MEDIA_URL,
             }))


### PR DESCRIPTION
When a form containing a upload fails to validate, and the `render()` method is called again to display form errors, it fails as `value` points to a `TemporaryUploadedFile` instance, which doesn't contain an attribute named 'field' as the regular `UploadedFile` from Django.

```
Traceback (most recent call last):

 File "/usr/local/lib/python2.6/dist-packages/django/core/handlers/base.py", line 99, in get_response
   response = callback(request, *callback_args, **callback_kwargs)

 File "/usr/local/lib/python2.6/dist-packages/django/contrib/admin/options.py", line 262, in wrapper
   return self.admin_site.admin_view(view)(*args, **kwargs)

 File "/usr/local/lib/python2.6/dist-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
   response = view_func(request, *args, **kwargs)

 File "/usr/local/lib/python2.6/dist-packages/django/contrib/admin/sites.py", line 186, in inner
   return view(request, *args, **kwargs)

 File "/usr/local/lib/python2.6/dist-packages/django/db/transaction.py", line 240, in _commit_on_success
   res = func(*args, **kw)

 File "/usr/local/lib/python2.6/dist-packages/django/contrib/admin/options.py", line 841, in add_view
   return self.render_change_form(request, context, form_url=form_url, add=True)

 File "/usr/local/lib/python2.6/dist-packages/django/contrib/admin/options.py", line 640, in render_change_form
   ], context, context_instance=context_instance)

 File "/usr/local/lib/python2.6/dist-packages/django/shortcuts/__init__.py", line 20, in render_to_response
   return HttpResponse(loader.render_to_string(*args, **kwargs), **httpresponse_kwargs)

 File "/usr/local/lib/python2.6/dist-packages/django/template/loader.py", line 108, in render_to_string
   return t.render(context_instance)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 165, in render
   return self.nodelist.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 784, in render
   bits.append(self.render_node(node, context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 797, in render_node
   return node.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/loader_tags.py", line 97, in render
   return compiled_parent.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 165, in render
   return self.nodelist.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 784, in render
   bits.append(self.render_node(node, context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 797, in render_node
   return node.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/loader_tags.py", line 97, in render
   return compiled_parent.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 165, in render
   return self.nodelist.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 784, in render
   bits.append(self.render_node(node, context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 797, in render_node
   return node.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/loader_tags.py", line 24, in render
   result = self.nodelist.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 784, in render
   bits.append(self.render_node(node, context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 797, in render_node
   return node.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/defaulttags.py", line 154, in render
   nodelist.append(node.render(context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/loader_tags.py", line 111, in render
   return self.template.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 165, in render
   return self.nodelist.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 784, in render
   bits.append(self.render_node(node, context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 797, in render_node
   return node.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/defaulttags.py", line 154, in render
   nodelist.append(node.render(context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/defaulttags.py", line 154, in render
   nodelist.append(node.render(context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/defaulttags.py", line 241, in render
   return self.nodelist_false.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 784, in render
   bits.append(self.render_node(node, context))

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 797, in render_node
   return node.render(context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 836, in render
   return _render_value_in_context(output, context)

 File "/usr/local/lib/python2.6/dist-packages/django/template/__init__.py", line 816, in _render_value_in_context
   value = force_unicode(value)

 File "/usr/local/lib/python2.6/dist-packages/django/utils/encoding.py", line 71, in force_unicode
   s = unicode(s)

 File "/usr/local/lib/python2.6/dist-packages/django/forms/forms.py", line 356, in __unicode__
   return self.as_widget()

 File "/usr/local/lib/python2.6/dist-packages/django/forms/forms.py", line 394, in as_widget
   return widget.render(name, data, attrs=attrs)

 File "/home/infra/src/django-stdimage/stdimage/widgets.py", line 17, in render
   'show_delete_button': value.field.blank,

AttributeError: 'TemporaryUploadedFile' object has no attribute 'field'
```
