### PR TITLE
Fixing "missing template" when installing with pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include stdimage/templates *

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,5 @@ setup(
         'Topic :: Software Development',
     ],
     packages=['stdimage'],
-    package_data={
-        'stdimage': [
-            'templates/stdimage/*.html',
-        ]
-    },
     requires=['django (>=1.0)',],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ setup(
     version='0.2.2',
     description='Django Standarized Image Field',
     author='garcia.marc',
-    author_email='garcia.marc@gmail.com',
     url='https://github.com/humanfromearth/django-stdimage',
+    author_email='garcia.marc@gmail.com',
     license='lgpl',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
@@ -20,5 +20,6 @@ setup(
         'Topic :: Software Development',
     ],
     packages=['stdimage'],
+    include_package_data=True,
     requires=['django (>=1.0)',],
 )


### PR DESCRIPTION
Currently when installing with pip, admin_widget.html is not included. setup.py includes it in package_data, but that is only for binary distributions. For source distribution, there is MANIFEST.in (see http://docs.python.org/2/distutils/sourcedist.html).
These modifications fix #17.
