### PR TITLE
Major recoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 django_stdimage.egg-info
+
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -30,12 +30,10 @@ Example::
     class MyClass(models.Model):
         image1 = StdImageField(upload_to='path/to/img') # works as ImageField
         image2 = StdImageField(upload_to='path/to/img', blank=True) # can be deleted throwgh admin
-        image3 = StdImageField(upload_to='path/to/img', size=(640, 480)) # resizes image to maximum size to fit a 640x480 area
-        image4 = StdImageField(upload_to='path/to/img', size=(640, 480, True)) # resizes image to 640x480 croping if necessary
-        image5 = StdImageField(upload_to='path/to/img', thumbnail_size=(100, 75)) # creates a thumbnail resized to maximum size to fit a 100x75 area
-        image6 = StdImageField(upload_to='path/to/img', thumbnail_size=(100, 100, True)) # creates a thumbnail resized to 100x100 croping if necessary
+        image3 = StdImageField(upload_to='path/to/img', variations={'thumbnail': (100, 75)}) # creates a thumbnail resized to maximum size to fit a 100x75 area
+        image4 = StdImageField(upload_to='path/to/img', variations={'thumbnail': (100, 100, True}) # creates a thumbnail resized to 100x100 croping if necessary
 
-        image_all = StdImageField(upload_to='path/to/img', blank=True, size=(640, 480), thumbnail_size=(100, 100, True)) # all previous features in one declaration
+        image_all = StdImageField(upload_to='path/to/img', blank=True, variations={'large': (640, 480), 'thumbnail': (100, 100, True)}) # all previous features in one declaration
 
 For using generated thumbnail in templates use "myimagefield.thumbnail". Example::
 
@@ -48,7 +46,8 @@ About image names
 
 StdImageField stores images in filesystem modifying its name. Renamed name is set using field name, and object primary key. Also it changes old windows "jpg" extesions to standard "jpeg".
 
-Using `image5` field previously defined (that creates a thumbnail), if an image called myimage.jpg is uploaded, then resulting images on filesystem would be (supose that this image belongs to a model with pk 14)::
+Using `image_all` field previously defined (that creates a thumbnail), if an image called myimage.jpg is uploaded, then resulting images on filesystem would be (supose that this image belongs to a model with pk 14)::
 
-    image5_14.jpeg
-    image5_14.thumbnail.jpeg
+    image_all_14.jpeg
+    image_all_14.large.jpeg
+    image_all_14.thumbnail.jpeg

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ setup(
     name='django-stdimage',
     version='0.4.0',
     description='Django Standarized Image Field',
-    author='Johannes Hoppe',
-    url='https://github.com/codingjoe/django-stdimage',
+    author='garcia.marc',
+    url='https://github.com/humanfromearth/django-stdimage',
     author_email='garcia.marc@gmail.com',
     license='lgpl',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 setup(
     name='django-stdimage',
-    version='0.2.3',
+    version='0.4.0',
     description='Django Standarized Image Field',
-    author='garcia.marc',
-    url='https://github.com/humanfromearth/django-stdimage',
+    author='Johannes Hoppe',
+    url='https://github.com/codingjoe/django-stdimage',
     author_email='garcia.marc@gmail.com',
     license='lgpl',
     classifiers=[

--- a/stdimage/fields.py
+++ b/stdimage/fields.py
@@ -96,8 +96,10 @@ class StdImageField(ImageField):
         param_size = ('width', 'height', 'force')
 
         variations = kwargs.pop('variations', {})
-        variations['size'] = size
-        variations['thumbnail'] = thumbnail_size
+        if not variations.has_key('size'):
+            variations['size'] = size
+        if not variations.has_key('thumbnail'):
+            variations['thumbnail'] = thumbnail_size
 
         var = []
 
@@ -215,7 +217,7 @@ class StdImageField(ImageField):
         if getattr(instance, self.name):
             filename = self.generate_filename(instance,
                                               os.path.basename(getattr(instance, self.name).path))
-            variation = getattr(self, 'thumbnail_size')
+            variation = getattr(self, 'thumbnail')
             thumbnail_filename = self._get_variation_filename(variation, filename)
             thumbnail_field = VariationField(thumbnail_filename)
             setattr(getattr(instance, self.name), 'thumbnail', thumbnail_field)
@@ -229,9 +231,10 @@ class StdImageField(ImageField):
             filename = self.generate_filename(instance,
                                               os.path.basename(getattr(instance, self.name).path))
             for variation in self.variations:
-                variation_filename = self._get_variation_filename(variation, filename)
-                variation_field = VariationField(variation_filename)
-                setattr(getattr(instance, self.name), variation['name'], variation_field)
+                if variation['name'] != 'size':
+                    variation_filename = self._get_variation_filename(variation, filename)
+                    variation_field = VariationField(variation_filename)
+                    setattr(getattr(instance, self.name), variation['name'], variation_field)
 
     def formfield(self, **kwargs):
         """Specify form field and widget to be used on the forms"""

--- a/stdimage/fields.py
+++ b/stdimage/fields.py
@@ -225,13 +225,13 @@ class StdImageField(ImageField):
         Variation attribute will be of the same class as the original image, so
         "path", "url"... properties can be used
         """
-        if getattr(instance, self.name) and isinstance(instance, VariationField):
+        if getattr(instance, self.name):
             filename = self.generate_filename(instance,
                                               os.path.basename(getattr(instance, self.name).path))
-            for variation in instance.variations:
+            for variation in self.variations:
                 variation_filename = self._get_variation_filename(variation, filename)
                 variation_field = VariationField(variation_filename)
-                setattr(getattr(instance, self.name), variation.name, variation_field)
+                setattr(getattr(instance, self.name), variation['name'], variation_field)
 
     def formfield(self, **kwargs):
         """Specify form field and widget to be used on the forms"""

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -1,30 +1,37 @@
 from django.db import models
 from stdimage import StdImageField
 
+
 class SimpleModel(models.Model):
     # works as ImageField
     image = StdImageField(upload_to='img')
+
 
 class AdminDeleteModel(models.Model):
     # can be deleted through admin
     image = StdImageField(upload_to='img', blank=True)
 
+
 class ResizeModel(models.Model):
     # resizes image to maximum size to fit a 640x480 area
     image = StdImageField(upload_to='img', size=(640, 480))
 
+
 class ResizeCropModel(models.Model):
     # resizes image to 640x480 croping if necessary
     image = StdImageField(upload_to='img', size=(640, 480, True))
+
 
 class ThumbnailModel(models.Model):
     # creates a thumbnail resized to maximum size to fit a 100x75 area
     image = StdImageField(upload_to='img', blank=True,
                           thumbnail_size=(100, 75))
 
+
 class ThumbnailCropModel(models.Model):
     # creates a thumbnail resized to 100x100 croping if necessary
     image = StdImageField(upload_to='img', thumbnail_size=(100, 100, True))
+
 
 class MultipleFieldsModel(models.Model):
     # creates a thumbnail resized to 100x100 croping if necessary
@@ -33,7 +40,8 @@ class MultipleFieldsModel(models.Model):
     image3 = StdImageField('Some label', upload_to='img')
     text = models.CharField('Some label', max_length=10)
 
+
 class AllModel(models.Model):
     # all previous features in one declaration
-    image = StdImageField(upload_to='img', blank=True, size=(640, 480),
-                              thumbnail_size=(100, 100, True))
+    image = StdImageField(upload_to='img', blank=True, variations={'size': (640, 480),
+                                                                   'thumbnail_size': (100, 100, True)})


### PR DESCRIPTION
Hi,

I didn't like the fact, that you were stuck with only one thumbnail size. That's why I rewrote some code.
The field now take a variations dictionary like that:
`StdImageField(upload_to='', variations={'thumbnail': (100,100, True), 'small': (800,800), 'extra_large':(1200,1200)})`

There still is legacy support, but it will raise a DeprecatedWarning.

What do you think?
